### PR TITLE
Styling updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The code snippets included in this repository were used in a WordPress v5.9.1 in
 
 - `./src/additional-css.css`
 
-  - CSS styles that get applied site-wide through the Additional CSS menu (from WP admin panel, Appearance -> Customize -> Additional CSS). This includes styles for things like the Platform Status indicator, which has CSS classes added to it through the WordPress editor GUI (`global-status` and `global-status-up`). Styles like this can be removed as components are built out via custom plugins.
+  - CSS styles that get applied site-wide through the Additional CSS menu (from WP admin panel, Appearance -> Customize -> Additional CSS). This includes styles for components like the Platform Status indicator, which has CSS classes added to it through the WordPress editor GUI (`global-status` and `global-status-up`). Styles like this can be removed as components are built out via custom plugins.
 
 - `./src/alert-banner.html`
   - HTML markup plus a `<style>` block to create an instance of the `warning` style [alert banner from the Design System](https://developer.gov.bc.ca/Design-System/Alert-Banners). This component is a candidate for future development as a custom plugin if we need multiple unique alert banner instances.

--- a/src/additional-css.css
+++ b/src/additional-css.css
@@ -84,6 +84,11 @@ div.pre-header ul li a.wp-block-button__link:hover {
   border-radius: 1px;
   color: #1a5a96;
 }
+/* Related Pages link block */
+div.related-pages {
+  background-color: rgb(155, 178, 197);
+  padding: 2em 1em;
+}
 /* Footer - ensure links within .footer-1 and .footer-2 are visible */
 footer.footer a {
   color: white;

--- a/src/additional-css.css
+++ b/src/additional-css.css
@@ -89,14 +89,30 @@ div.related-pages {
   background-color: rgb(155, 178, 197);
   padding: 2em 1em;
 }
-/* Footer - ensure links within .footer-1 and .footer-2 are visible */
-footer.footer a {
-  color: white;
-}
 /* Utility class to add a light grey border to any div */
 div.border-rectangle {
   padding: 0.5em 1em;
   border: 1px solid rgb(225, 225, 225);
+}
+
+/* ------ */
+/* Footer */
+/* ------ */
+/* Ensure links within .footer-1 and .footer-2 are visible */
+footer.footer a {
+  color: white;
+}
+/* Fix compressed footer elements */
+footer.footer > section.footer-1 > div.container > div.row {
+  width: 100%;
+}
+footer.footer
+  > section.footer-1
+  > div.container
+  > div.row
+  > aside.col-sm-3.widget.widget_block {
+  flex: auto;
+  max-width: 100%;
 }
 
 /* -------- */

--- a/src/alert-banner.html
+++ b/src/alert-banner.html
@@ -27,7 +27,10 @@
     width: 21px;
     height: 20px;
   }
-  div.bc-gov-alertbanner-warning a {
+  div.wp-block-engagement-container
+    div.wp-block-engagement-content
+    div.bc-gov-alertbanner-warning
+    a {
     color: #66512c;
   }
   div.bc-gov-alertbanner p.warning-desc {


### PR DESCRIPTION
This pull request includes the following commits:

- Styling for the "Related Pages" block added to `./src/additional-css.css` (079ef25):
<img width="1840" alt="Screen Shot 2022-05-10 at 12 31 38 PM" src="https://user-images.githubusercontent.com/25143706/167707552-5da8942b-3fba-4a61-aaeb-9512ee4ff7c0.png">

- An update to `./src/alert-banner.html` for better CSS specificity (b5c81e6)

- README wording update (fde2051)

- Fix for compressed footer elements (20948f8)