### PR TITLE
Search styling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/src/additional-css.css
+++ b/src/additional-css.css
@@ -1,12 +1,11 @@
 /* ------ */
 /* Global */
 /* ------ */
-/* Search - don't want WordPress search, theme doesn't let us remove it */
-#bcgov-search {
-  display: none;
-}
-bcgov-button .search {
-  display: none;
+/* Search form container */
+bcgov-header header div.bcgov-search-container {
+  flex-grow: 1;
+  flex-shrink: 1;
+  flex-basis: auto;
 }
 /* Links within Engagement containers */
 div.wp-block-engagement-container div.wp-block-engagement-content a,

--- a/src/additional-css.css
+++ b/src/additional-css.css
@@ -7,6 +7,38 @@ bcgov-header header div.bcgov-search-container {
   flex-shrink: 1;
   flex-basis: auto;
 }
+/* Search results page */
+body.search.search-results div.wp-block-engagement-content article {
+  border-bottom: none;
+  padding-bottom: 0;
+}
+body.search.search-results
+  div.wp-block-engagement-content
+  article:first-of-type {
+  margin-top: 1rem;
+}
+body.search.search-results
+  div.wp-block-engagement-content
+  article
+  h2.entry-title {
+  font-size: 18px;
+}
+body.search.search-results
+  div.wp-block-engagement-content
+  article
+  h2.entry-title
+  a:hover {
+  color: #2b4777;
+  text-decoration: none;
+}
+body.search.search-results div.pagination {
+  display: block;
+  margin: 2.5rem 0 1.5rem 0;
+  text-align: center;
+}
+body.search.search-results div.pagination > a {
+  margin: 0 0.25rem;
+}
 /* Links within Engagement containers */
 div.wp-block-engagement-container div.wp-block-engagement-content a,
 div.wp-block-engagement-container div.wp-block-engagement-content a.active,


### PR DESCRIPTION
This PR adds styling to display the search form (which was previously set to `display: none`) and to make the results page look nice.

<img width="1840" alt="Homepage showing search form on the right side of site header" src="https://user-images.githubusercontent.com/25143706/183221068-83e4c4a6-de57-4f8b-a346-6b672700ab49.png">

<img width="1840" alt="Search results page" src="https://user-images.githubusercontent.com/25143706/183221138-69e8a614-c0d5-4dde-8d1c-cffb40bb89e7.png">
